### PR TITLE
feat(workflow): add SDK parity dispatch workflow

### DIFF
--- a/.github/workflows/sdk-parity-dispatch.yml
+++ b/.github/workflows/sdk-parity-dispatch.yml
@@ -1,0 +1,17 @@
+name: SDK Parity Dispatch
+
+on:
+  push:
+    paths:
+      - "*.go"
+      - "go.mod"
+  pull_request:
+    paths:
+      - "*.go"
+      - "go.mod"
+  workflow_dispatch:
+
+jobs:
+  parity-dispatch:
+    uses: tapsilat/tapsilat-sdk-parity/.github/workflows/reusable-sdk-parity-dispatch.yml@main
+    secrets: inherit


### PR DESCRIPTION
- Introduced a new GitHub Actions workflow for SDK parity dispatch.
- Triggers on push and pull request events for Go files and go.mod.
- Utilizes a reusable workflow from tapsilat/tapsilat-sdk-parity.
- Inherits secrets for secure operations.